### PR TITLE
練習用なのでマージ不要です

### DIFF
--- a/form.html
+++ b/form.html
@@ -10,6 +10,8 @@
 	<form method="post" action="/enquetes/yaki-shabu">
 		<input type="radio" name="yaki-shabu" value="焼き肉" /> 焼き肉
 		<input type="radio" name="yaki-shabu" value="しゃぶしゃぶ" /> しゃぶしゃぶ
+		<br>
+		なまえ：<input type="text" name="name"> 
 		<button type="submit">投稿</button>
 	</form>
 </body>

--- a/index.js
+++ b/index.js
@@ -17,9 +17,23 @@ const server = http.createServer((req, res) => {
 		case 'POST':
 			req.on('data', (data) => {
 				const decoded = decodeURIComponent(data);
+				const decoded_array = decoded.split("&");
+				let data_array =[];
+				let tx = {name : '匿名子', yaki_shabu : '秘密'};
+				for (let i=0; i<decoded_array.length; i++){
+					let data_array = decoded_array[i].split("=");
+					switch (data_array[0]){
+						case 'name' :
+							tx.name = (data_array[1] || tx.name)
+							break;
+						case 'yaki-shabu':
+							tx.yaki_shabu = (data_array[1] || tx.yaki_shabu)
+					}
+				}
 				console.info('[' + now + '] 投稿: ' + decoded);
 				res.write('<!DOCTYPE html><html lang="jp"><head><meta charset="utf-8"></head><body><h1>' +
-					decoded + 'が投稿されました</h1></body></html>');
+					tx.name+'の食べたいものは、'+
+					tx.yaki_shabu + 'であると申告されました</h1></body></html>');
 				res.end();
 			});
 			break;

--- a/index.js
+++ b/index.js
@@ -18,7 +18,6 @@ const server = http.createServer((req, res) => {
 			req.on('data', (data) => {
 				const decoded = decodeURIComponent(data);
 				const decoded_array = decoded.split("&");
-				let data_array =[];
 				let tx = {name : '匿名子', yaki_shabu : '秘密'};
 				for (let i=0; i<decoded_array.length; i++){
 					let data_array = decoded_array[i].split("=");

--- a/index.js
+++ b/index.js
@@ -23,10 +23,10 @@ const server = http.createServer((req, res) => {
 					let data_array = decoded_array[i].split("=");
 					switch (data_array[0]){
 						case 'name' :
-							tx.name = (data_array[1] || tx.name)
+							tx.name = (data_array[1] || tx.name);
 							break;
 						case 'yaki-shabu':
-							tx.yaki_shabu = (data_array[1] || tx.yaki_shabu)
+							tx.yaki_shabu = (data_array[1] || tx.yaki_shabu);
 					}
 				}
 				console.info('[' + now + '] 投稿: ' + decoded);


### PR DESCRIPTION
name=hoge&yaki-shabu=焼き肉、とかだとそのままでは役に立たない気がするから、手動で分解しようと試みたが、どうも面倒だ！きっと一発で分解する便利技があるに違いない。

手動でぶつかったいくつかの問題
1)名前の中に＆が入っていたら、＆によるsplitで意図した動作をしなくなる（未解決）
2)結果を分解して格納する変数tx={}は、HTMLのnameをそのままプロパティ名にしたオブジェクトにすればいいかと思ったけど、yaki-shabuのハイフンのおかげでそうもいかない。
3)textは空送信しても'name='という文字列がdataに入るけど、radioの場合はどちらも選ばなかったら’yaki-shabu=’という文字列はdataに入ってこないので、未入力に対して同じ処理ができない。

など、想定外を考慮しないといけないのは勉強になる。＆は対策できてないけど。